### PR TITLE
Add model restriction to metaConfig

### DIFF
--- a/ilivalidatorws-server/src/main/resources/ini/drainagen-meta.ini
+++ b/ilivalidatorws-server/src/main/resources/ini/drainagen-meta.ini
@@ -1,2 +1,5 @@
 [CONFIGURATION]
 ch.interlis.referenceData=ilidata:vsa_organisationen
+
+[ch.ehi.ilivalidator]
+models=VSADSSMINI_2020_LV95

--- a/ilivalidatorws-server/src/main/resources/ini/ipw-meta.ini
+++ b/ilivalidatorws-server/src/main/resources/ini/ipw-meta.ini
@@ -1,2 +1,5 @@
 [CONFIGURATION]
 ch.interlis.referenceData=ilidata:vsa_organisationen
+
+[ch.ehi.ilivalidator]
+models=VSADSSMINI_2020_LV95


### PR DESCRIPTION
Um zu verhindern, dass Daten validiert werden, die im falschen Modell hochgeladen werden (d. h. verhindern lässt sich das nicht, aber es hagelt dann ganz viele Fehler in der Form `unknown class`).

Sollte man das `--allObjectsAccessible` auch in die config.ini oder metaConfig.ini packen? Was ist da für eure Workflows am sinnvollsten?